### PR TITLE
Update Kyoto frame work and Fix index page view

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/kyoto-framework/new
 
 go 1.21.3
 
-require go.kyoto.codes/v3 v3.0.0
+require go.kyoto.codes/v3 v3.1.0
 
-require go.kyoto.codes/zen/v3 v3.0.0 // indirect
+require go.kyoto.codes/zen/v3 v3.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-go.kyoto.codes/v3 v3.0.0 h1:gD7JvW3p14iA5BIaMsvcLHOVyzjg+En0y1ETCRUHkX8=
-go.kyoto.codes/v3 v3.0.0/go.mod h1:nTirQjQVQk2QILk+gFpugQYmzoqTQ+5vCqJUjSF7bII=
-go.kyoto.codes/zen/v3 v3.0.0 h1:USERmDZJlJYrMnTK/2e8b0JCa5X9AXCC4iULwD/+SB4=
-go.kyoto.codes/zen/v3 v3.0.0/go.mod h1:mL1cTOqQ9EgZ1QeItYltjO4MPQakLXz/Xeu+dd/LO1g=
+go.kyoto.codes/v3 v3.1.0 h1:4YxMT+9HodPmnvxgMrA9P78GeJ0OEMEODlTi4OWSO4o=
+go.kyoto.codes/v3 v3.1.0/go.mod h1:nTirQjQVQk2QILk+gFpugQYmzoqTQ+5vCqJUjSF7bII=
+go.kyoto.codes/zen/v3 v3.1.0 h1:90HOg8T/DJ95jwAcUqcE+IXPPWVd1tkZcyWVf6p8nlM=
+go.kyoto.codes/zen/v3 v3.1.0/go.mod h1:mL1cTOqQ9EgZ1QeItYltjO4MPQakLXz/Xeu+dd/LO1g=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ func setup() *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Setup assets
-	mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("assets-dist"))))
+	mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("assets"))))
 
 	// Setup pages
 	mux.Handle("/", rendering.Handler(IndexPage))

--- a/page.index.go.html
+++ b/page.index.go.html
@@ -8,8 +8,7 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Kyoto Project</title>
-    <link rel="stylesheet" href="/assets/css/tailwind.min.css">
-    <link rel="stylesheet" href="/assets/css/bundle.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
 <div class="h-screen w-screen flex flex-col items-center justify-center gap-8">
@@ -23,7 +22,6 @@
         and kyoto itself as a basis.
     </div>
 </div>
-<script src="/assets/js/bundle.min.js"></script>
 </body>
 </html>
 {{ end }}


### PR DESCRIPTION
It did not display correctly when I run this repo when I built and displayed.

# What is changed
- Update Kyoto framework version (This is because a newer version had been released, and is not due to a display error in index page)
- Fix index page view
  -  fix assets file path which is defined in main.go
  - change css import 
    - Change Tailwind import link tag to script tag
    - Remove bundle.min.js(BootStrap?) import
# ScreenShot
## Before Fix ![image](https://github.com/kyoto-framework/new/assets/44843589/4cbdfe0b-5640-4844-985b-bd1a11572eb4)
## After Fix ![image](https://github.com/kyoto-framework/new/assets/44843589/04ba0ac4-3549-485c-9d52-4de0d0b98c03)